### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build-linux:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ElliNet13/eedex-ui/security/code-scanning/8](https://github.com/ElliNet13/eedex-ui/security/code-scanning/8)

The best way to fix the issue is to add an explicit `permissions:` block to the workflow file to control the GITHUB_TOKEN privileges. In general, the block should be placed at the top-level (root) for the whole workflow, unless jobs need different permissions. Reviewing the uses of GITHUB_TOKEN, this workflow uploads release assets via `ncipollo/release-action@v1` (requires `contents: write`), while the rest of the workflow can operate with `contents: read`. Therefore, set `permissions: contents: read` at the workflow root, then override with `permissions: contents: write` for the release upload job or step as needed. 

In this code snippet, the upload to GitHub Release is a step within the `build-linux` job, not a separate job. The cleanest fix is to add `permissions: contents: write` to the build-linux job, as the upload step requires write access. For an even stricter approach, the GITHUB_TOKEN could be passed only to the step that requires it, but in the context of this workflow, a job-level override is most practical.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
